### PR TITLE
Corregí la redirección desde ProximosFragment a DetalleFragment. Deta…

### DIFF
--- a/app/src/main/java/com/example/yesii/jujuyeventos/AdapterProximo.java
+++ b/app/src/main/java/com/example/yesii/jujuyeventos/AdapterProximo.java
@@ -1,6 +1,7 @@
 package com.example.yesii.jujuyeventos;
 
 
+import android.support.v4.app.FragmentManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/app/src/main/java/com/example/yesii/jujuyeventos/DetalleFragment.java
+++ b/app/src/main/java/com/example/yesii/jujuyeventos/DetalleFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -81,8 +82,9 @@ public class DetalleFragment extends Fragment {
             txtDetalle =(TextView) view.findViewById(R.id.detalleTxt);
             txtPrecio1 =(TextView) view.findViewById(R.id.precio1Txt);
             txtTitulo.setText(evento.getTitulo());
+            System.out.println("TITULO EN DETALLE: " + evento.getTitulo());
             txtLugar1.setText("LUGAR: " + evento.getLugar1());
-            txtFecha.setText("FECHA: " + evento.getFecha());
+//            txtFecha.setText("FECHA: " + evento.getFecha());
             txtHora1.setText("HORA: " + evento.getHora1());
             txtDetalle.setText(evento.getDetalle());
             txtPrecio1.setText("PRECIO: " + evento.getPrecio1());

--- a/app/src/main/java/com/example/yesii/jujuyeventos/ProximosFragment.java
+++ b/app/src/main/java/com/example/yesii/jujuyeventos/ProximosFragment.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -45,8 +46,9 @@ public class ProximosFragment extends Fragment {
         getEventoList();
 
         adapterProximo= new AdapterProximo(eventos, new AdapterProximo.OnItemClickListener() {
-            @Override public void onItemClick(Evento item) {
-                Toast.makeText(getContext(), "Item Clicked", Toast.LENGTH_LONG).show();
+            @Override public void onItemClick(Evento evento) {
+                Toast.makeText(getContext(), "Item Clicked" + evento.getTitulo(), Toast.LENGTH_LONG).show();
+                interfaceComunicateFragment.enviarEvento(evento);
             }
         });
 

--- a/app/src/main/java/com/example/yesii/jujuyeventos/SegundaActivity.java
+++ b/app/src/main/java/com/example/yesii/jujuyeventos/SegundaActivity.java
@@ -97,8 +97,11 @@ public class SegundaActivity extends AppCompatActivity  implements ProximosFragm
         Bundle bundleEnvio = new Bundle();
         bundleEnvio.putSerializable("objeto",evento);
         detalle.setArguments(bundleEnvio);
-        mSectionsPagerAdapter.getItem(0).getFragmentManager().beginTransaction().replace(R.id.containerId,detalle).commit();
-
+//        this.getSupportFragmentManager().beginTransaction().replace(R.id.containerId,detalle).commit();
+        this.getSupportFragmentManager().beginTransaction()
+                .replace(R.id.containerId, detalle, detalle.getTag())
+                .addToBackStack(null)
+                .commit();
     }
 
 


### PR DESCRIPTION
Corregí la redirección desde `ProximosFragment` a `DetalleFragment`. 
`DetalleFragment` está recibiendo los datos seleccionados en el Fragment anterior. Esto se puede ver en el Log, donde el valor del título seleccionado llega correctamente.
Ahora el nuevo inconveniente (tal vez el último) es que `DetalleFragment` se muestra vacío o no está mostrando los valores que está recibiendo.